### PR TITLE
Corrected link at end of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ To build your own container with a Dockerfile and additional dependencies, pull 
 FROM harbor.cyverse.org/vice/jupyter/datascience:latest
 ```
 
-Follow the instructions in the [VICE manual for integrating your own tools and apps](https://cyverse-visual-interactive-computing-environment.readthedocs-hosted.com/en/latest/developer_guide/building.html).
+Follow the instructions in the [VICE manual for integrating your own tools and apps](https://learning.cyverse.org/vice/extend_apps/#building-an-app-for-your-tool).


### PR DESCRIPTION
The link at the end of the README gave me a 404 error, but I found a page that I think is appropriate for that link. Let me know if this is not what was intended.