### PR TITLE
Add GitHub CLI integration and optimize Docker build for K8s deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,43 @@
 
 ---
 
-[Project Jupyter](https://jupyter.org/) Datascience Notebook with a few added packages for use in [CyVerse Discovery Environment](https://de.cyverse.org)
+[Project Jupyter](https://jupyter.org/) Datascience Notebook with additional packages and tools for use in [CyVerse Discovery Environment](https://de.cyverse.org)
 
-Jupyter Lab Datascience image built from the [Datascience Notebook](https://hub.docker.com/r/jupyter/datascience-notebook) for [CyVerse VICE](https://cyverse-visual-interactive-computing-environment.readthedocs-hosted.com/en/latest/index.html). Project Jupyter's base image requires a couple additional configuration files for it be compatible with CyVerse Kubernetes orchestration and iRODS data store.
+Jupyter Lab Datascience image built from the [Datascience Notebook](https://hub.docker.com/r/jupyter/datascience-notebook) for [CyVerse VICE](https://cyverse-visual-interactive-computing-environment.readthedocs-hosted.com/en/latest/index.html). This image includes GitHub CLI, enhanced K8s CSI driver support, and optimized build layers for improved performance and reproducibility in CyVerse Kubernetes orchestration with iRODS data store integration.
 
 [![!Harbor](https://github.com/cyverse-vice/jupyterlab-datascience/actions/workflows/harbor.yml/badge.svg)](https://github.com/cyverse-vice/jupyterlab-datascience/actions) ![GitHub commits since tagged version](https://img.shields.io/github/commits-since/cyverse-vice/jupyterlab-datascience/latest/main?style=flat-square) 
 
-| quick launch | 
-| ------------ | 
+| quick launch |
+| ------------ |
 | <a href="https://de.cyverse.org/apps/de/cc77b788-bc45-11eb-9934-008cfa5ae621/launch" target="_blank"><img src="https://img.shields.io/badge/Datascience-latest-orange?style=plastic&logo=jupyter"></a> |
 | <a href="https://de.cyverse.org/apps/de/0bb01716-5d03-11ec-b195-008cfa5ae621/launch" target="_blank"><img src="https://img.shields.io/badge/Geospatial-latest-orange?style=plastic&logo=jupyter"></a> |
 | <a href="https://de.cyverse.org/apps/de/c2227314-1995-11ed-986c-008cfa5ae621/launch" target="_blank"><img src="https://img.shields.io/badge/RStudio-latest-orange?style=plastic&logo=r"></a> |
+
+## Features
+
+This image includes the following additional tools and features beyond the base Jupyter datascience notebook:
+
+### Development Tools
+- **GitHub CLI (`gh`)** - Command-line tool for GitHub operations
+- **Git Credential Manager** - Secure credential storage for Git operations
+- **VS Code Server** - Browser-based VS Code environment
+- **Jupyter AI** - AI assistant integration for Jupyter notebooks
+
+### Data Science & Analytics
+- **RStudio Server** - Web-based R development environment
+- **Shiny Server** - Host interactive R applications
+- **GoCommands** - CyVerse data transfer utilities
+- **iRODS integration** - Direct access to CyVerse data store
+
+### System Utilities
+- **Enhanced monitoring** - htop, glances for system monitoring
+- **Development tools** - gcc, build essentials, package managers
+- **Kubernetes CSI driver support** - Automatic environment file sourcing
+
+### Security Features
+- **Sudo access** for jovyan user (configurable permissions)
+- **Secure credential management** with Git Credential Manager
+- **Environment file sourcing** from K8s CSI driver mounted secrets
 
 ## Development
 

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -1,21 +1,43 @@
 # https://quay.io/repository/jupyter/datascience-notebook
+# CyVerse Datascience Notebook with GitHub CLI, optimized for K8s deployment
 FROM quay.io/jupyter/datascience-notebook:latest
 USER root
 
-# Install a few dependencies for goCommands, text editing, and monitoring instances
+# Install system dependencies, GitHub CLI, and tools in a single layer
 RUN apt update && \
-    apt install -y lsb-release apt-transport-https curl libfreetype6-dev pkg-config libx11-dev gcc gettext less software-properties-common apt-utils glances htop nano 
+    apt install -y \
+        lsb-release \
+        apt-transport-https \
+        curl \
+        wget \
+        libfreetype6-dev \
+        pkg-config \
+        libx11-dev \
+        gcc \
+        gettext \
+        less \
+        software-properties-common \
+        apt-utils \
+        glances \
+        htop \
+        nano \
+        sudo \
+        gdebi-core \
+        gnupg2 && \
+    # Install GitHub CLI
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt update && \
+    apt install -y gh && \
+    # Clean up
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
-# Install GoCommands https://learning.cyverse.org/ds/gocommands/ 
+# Install GoCommands https://learning.cyverse.org/ds/gocommands/
 RUN cd /usr/local/bin/ && \
     GOCMD_VER=$(curl -L -s https://raw.githubusercontent.com/cyverse/gocommands/main/VERSION.txt); \
     curl -L -s https://github.com/cyverse/gocommands/releases/download/${GOCMD_VER}/gocmd-${GOCMD_VER}-linux-amd64.tar.gz | tar zxvf -
-
-# Add sudo to jovyan user
-RUN apt update && \
-    apt install -y sudo && \
-    apt clean && \
-    rm -rf /var/lib/apt/lists/*
     
 ARG LOCAL_USER=jovyan
 
@@ -29,23 +51,23 @@ RUN usermod -aG sudo jovyan && \
 RUN addgroup jovyan
 RUN usermod -aG jovyan jovyan
 
-# Install RStudio
-RUN apt update && apt install --yes gdebi-core && \
-    wget https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2025.09.0-387-amd64.deb && \
-    gdebi -n rstudio-server-2025.05.1-513-amd64.deb && \
-    rm rstudio-server-2025.05.1-513-amd64.deb && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install RStudio (pinned version for reproducibility)
+ARG RSTUDIO_VERSION=2025.09.0-387
+RUN wget https://download2.rstudio.org/server/jammy/amd64/rstudio-server-${RSTUDIO_VERSION}-amd64.deb && \
+    gdebi -n rstudio-server-${RSTUDIO_VERSION}-amd64.deb && \
+    rm rstudio-server-${RSTUDIO_VERSION}-amd64.deb
 
-# Install Shiny Server
-RUN wget https://download3.rstudio.org/ubuntu-20.04/x86_64/shiny-server-1.5.23.1030-amd64.deb && \
-    gdebi -n shiny-server-1.5.23.1030-amd64.deb && \
-    rm shiny-server-1.5.23.1030-amd64.deb && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# Install Shiny Server (pinned version for reproducibility)
+ARG SHINY_VERSION=1.5.23.1030
+RUN wget https://download3.rstudio.org/ubuntu-20.04/x86_64/shiny-server-${SHINY_VERSION}-amd64.deb && \
+    gdebi -n shiny-server-${SHINY_VERSION}-amd64.deb && \
+    rm shiny-server-${SHINY_VERSION}-amd64.deb
 
-# install git-credential-manager 
-RUN wget https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.6.1/gcm-linux_amd64.2.6.1.deb
-RUN dpkg -i gcm-linux_amd64.2.6.1.deb && \
-    rm gcm-linux_amd64.2.6.1.deb
+# Install git-credential-manager (pinned version for reproducibility)
+ARG GCM_VERSION=2.6.1
+RUN wget https://github.com/git-ecosystem/git-credential-manager/releases/download/v${GCM_VERSION}/gcm-linux_amd64.${GCM_VERSION}.deb && \
+    dpkg -i gcm-linux_amd64.${GCM_VERSION}.deb && \
+    rm gcm-linux_amd64.${GCM_VERSION}.deb
 
 # set the ENV for the credential type
 ENV GCM_CREDENTIAL_STORE=cache

--- a/latest/entry.sh
+++ b/latest/entry.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+# Create iRODS configuration
 mkdir -p $HOME/.irods
 touch $HOME/.irods/irods_environment.json
 echo '{"irods_host": "data.cyverse.org", "irods_port": 1247, "irods_user_name": "$IPLANT_USER", "irods_zone_name": "iplant"}' >> $HOME/.irods/irods_environment.json
 
+# Add conda to PATH
 echo "export PATH=$PATH:/opt/conda/bin" >> ~/.bashrc
 
+# Copy configuration files from data store (legacy method)
 if [ -f /data-store/iplant/home/$IPLANT_USER/.gitconfig ]; then
   cp /data-store/iplant/home/$IPLANT_USER/.gitconfig ~/
 fi
@@ -13,5 +16,26 @@ fi
 if [ -d /data-store/iplant/home/$IPLANT_USER/.ssh ]; then
   cp -r /data-store/iplant/home/$IPLANT_USER/.ssh ~/
 fi
+
+# Source hidden environment files provided by K8s CSI driver
+# These files will be mounted to /home/jovyan/ by the K8s CSI driver
+for env_file in /home/jovyan/.*env*; do
+  if [ -f "$env_file" ] && [ -r "$env_file" ]; then
+    echo "Sourcing environment file: $env_file"
+    set -a  # automatically export all variables
+    source "$env_file"
+    set +a  # disable automatic export
+  fi
+done
+
+# Source any .env files in the home directory
+for env_file in /home/jovyan/.env*; do
+  if [ -f "$env_file" ] && [ -r "$env_file" ]; then
+    echo "Sourcing environment file: $env_file"
+    set -a  # automatically export all variables
+    source "$env_file"
+    set +a  # disable automatic export
+  fi
+done
 
 exec jupyter lab --no-browser --LabApp.token="" --LabApp.password="" --ip="0.0.0.0" --port=8888


### PR DESCRIPTION
- Integrate GitHub CLI (gh) with official repository installation
- Fix RStudio version mismatch bug (2025.09.0-387 vs 2025.05.1-513)
- Consolidate package installations into single layer for build efficiency
- Add version pinning for RStudio, Shiny Server, and Git Credential Manager
- Update entry.sh to support K8s CSI driver environment file sourcing
- Enhanced README with comprehensive feature documentation
- Optimize build layers and add cleanup steps for smaller image size

🤖 Generated with [Claude Code](https://claude.com/claude-code)