### PR TITLE
Fix GitHub Actions Docker registry integration

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -3,46 +3,52 @@ name: harbor
 on:
   push:
     branches: main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker image tag to build'
+        required: false
+        default: 'latest'
+        type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3 # Updated to latest version
-      
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3 # Updated to latest version
-      
+        uses: docker/setup-buildx-action@v3
+
       - name: Cache Docker layers
-        uses: actions/cache@v3 # Updated to latest version
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      
-      - name: Login to harbor
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2 # Updated to latest version
+
+      - name: Login to Harbor
+        uses: docker/login-action@v3
         with:
           registry: harbor.cyverse.org
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
-      
+
       - name: Build and push latest
         id: docker_build_latest
-        uses: docker/build-push-action@v3 # Updated to latest version
+        uses: docker/build-push-action@v5
         with:
-          context: latest 
+          context: latest
           file: latest/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: harbor.cyverse.org/vice/jupyter/datascience:latest
+          tags: harbor.cyverse.org/vice/jupyter/datascience:${{ inputs.tag || 'latest' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-      
+
       - name: Image digest
-        run: echo ${{ steps.docker_build_latest.outputs.digest }} # This might need adjustment based on the step you want to echo the digest from
+        run: echo ${{ steps.docker_build_latest.outputs.digest }}


### PR DESCRIPTION
- Add workflow_dispatch for manual triggering with optional tag input
- Update action versions: checkout@v4, cache@v4, login-action@v3, build-push-action@v5
- Remove conditional on login step to always authenticate
- Support custom tag via workflow dispatch (defaults to 'latest')