### PR TITLE
fix: npm-based Claude Code install, GCM v2.7.3, Actions Node24

### DIFF
--- a/.github/workflows/harbor.yml
+++ b/.github/workflows/harbor.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.context || 'latest' }}
           file: ${{ inputs.context || 'latest' }}/Dockerfile

--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -66,7 +66,7 @@ RUN wget -q https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2024
          -O /tmp/rstudio-server.deb && \
     wget -q https://download3.rstudio.org/ubuntu-20.04/x86_64/shiny-server-1.5.23.1030-amd64.deb \
          -O /tmp/shiny-server.deb && \
-    wget -q https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.6.1/gcm-linux_amd64.2.6.1.deb \
+    wget -q https://github.com/git-ecosystem/git-credential-manager/releases/download/v2.7.3/gcm-linux-x64-2.7.3.deb \
          -O /tmp/gcm.deb && \
     gdebi -n /tmp/rstudio-server.deb && \
     gdebi -n /tmp/shiny-server.deb && \
@@ -83,13 +83,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
 USER jovyan
 WORKDIR /home/jovyan
 
-# Install Claude Code using official installer
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
-# Install OpenAI Codex and Google Gemini CLI via npm
+# Install Claude Code, OpenAI Codex, and Google Gemini CLI via npm
 RUN npm config set prefix /home/jovyan/.npm-global && \
     export PATH=/home/jovyan/.npm-global/bin:$PATH && \
-    npm install -g @google/gemini-cli @openai/codex && \
+    npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex && \
     npm cache clean --force
 ENV PATH="/home/jovyan/.npm-global/bin:${PATH}"
 


### PR DESCRIPTION
## Summary
- Replace fragile curl-pipe-bash Claude Code installer with `npm install -g @anthropic-ai/claude-code`
- Update GCM v2.6.1 → v2.7.3 (new filename convention: `gcm-linux-x64-*.deb`)
- Bump `actions/checkout` v4 → v5, `actions/cache` v4 → v5, `docker/build-push-action` v5 → v6 for Node24 compat

## Test plan
- [ ] Verify Docker image builds successfully with `docker build -f latest/Dockerfile latest/`
- [ ] Confirm `claude` CLI is available at `/home/jovyan/.npm-global/bin/claude`
- [ ] Confirm `git-credential-manager` version reports 2.7.3
- [ ] Verify GitHub Actions workflow runs without deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)