### PR TITLE
fix: add --no-modify-path to opencode install (prevent Docker build hang)

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -89,7 +89,7 @@ RUN npm config set prefix /home/jovyan/.npm-global && \
     npm cache clean --force
 
 # Install OpenCode (https://opencode.ai/)
-RUN curl -fsSL https://opencode.ai/install | bash
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path
 
 ENV PATH="/home/jovyan/.npm-global/bin:/home/jovyan/.opencode/bin:${PATH}"
 


### PR DESCRIPTION
fix: add --no-modify-path to opencode install

The opencode installer tries to detect the current shell and modify config files (.bashrc, .zshrc, etc.). In a Docker build context this can hang indefinitely since there's no interactive shell to detect.

Adding `--no-modify-path` skips that step entirely — PATH is already set via the ENV instruction.